### PR TITLE
rename sync to s3sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "deploy": "sls deploy -v",
     "remove": "sls remove",
-    "sync": "sls sync",
+    "sync": "sls s3sync",
     "test": "nyc ava -v",
     "lint": "eslint ."
   },


### PR DESCRIPTION
I ran `npm run sync` then the following error is occured.

```
  Serverless Error ---------------------------------------

  Serverless command "sync" not found. Did you mean "s3sync"? Run "serverless help" for a list of all available commands.
```

after that I have renamed sync to s3sync and worked fine.